### PR TITLE
Update service to 32.4.4

### DIFF
--- a/nano_32_4/Dockerfile.template
+++ b/nano_32_4/Dockerfile.template
@@ -3,9 +3,12 @@ FROM balenalib/jetson-nano-ubuntu:bionic
 # Prevent apt-get prompting for input
 ENV DEBIAN_FRONTEND noninteractive
 
+# Update to 32.4.4 repository if the base image uses an older one
+RUN sed -i 's/r32 main/r32.4 main/g' /etc/apt/sources.list.d/nvidia.list
+
 RUN apt-get update && apt-get install -y wget tar lbzip2 python3 libegl1 && \
-    wget https://developer.nvidia.com/embedded/L4T/r32_Release_v4.2/t210ref_release_aarch64/Tegra210_Linux_R32.4.2_aarch64.tbz2 && \
-    tar xf Tegra210_Linux_R32.4.2_aarch64.tbz2 && \
+    wget https://developer.nvidia.com/embedded/L4T/r32_Release_v4.4/r32_Release_v4.4-GMC3/T210/Tegra210_Linux_R32.4.4_aarch64.tbz2 && \
+    tar xf Tegra210_Linux_R32.4.4_aarch64.tbz2 && \
     cd Linux_for_Tegra && \
     sed -i 's/config.tbz2\"/config.tbz2\" --exclude=etc\/hosts --exclude=etc\/hostname/g' apply_binaries.sh && \
     sed -i 's/install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/#install --owner=root --group=root \"${QEMU_BIN}\" \"${L4T_ROOTFS_DIR}\/usr\/bin\/\"/g' nv_tegra/nv-apply-debs.sh && \


### PR DESCRIPTION
In L32.4.X, the Nvidia kernel from
meta-tegra does not mention the patchset
anymore in uname, it only mentions 32.4. However,
the rootfs for the current Jetson Nano
v2.67.3 release is now based on 32.4.4 and therefore
we can use the corresponding BSP archive.

Signed-off-by: Alexandru Costache <alexandru@balena.io>